### PR TITLE
Revise base and equality linker and avoid links within the same maven…

### DIFF
--- a/src/cfgnet/linker/equality_linker.py
+++ b/src/cfgnet/linker/equality_linker.py
@@ -21,6 +21,26 @@ from cfgnet.linker.linker import Linker
 class EqualityLinker(Linker):
     """Equality-based Linker."""
 
+    def create_links(self) -> None:
+        self.target_nodes = self._find_target_nodes()
+
+        for node in self.target_nodes:
+            if not node.name:
+                return
+
+            # discard words from static blacklist
+            if self.network:
+                if self.network.cfg.enable_static_blacklist:
+                    if node.name in self.static_blacklist.values:
+                        return
+
+            # find all matches with the given linker criterion
+            matches = self._find_matches(node)
+
+            # add link for all matches
+            for match in matches:
+                self._add_link(node, match)
+
     def _find_target_nodes(self):
         return [
             node
@@ -29,8 +49,25 @@ class EqualityLinker(Linker):
         ]
 
     def _find_matches(self, node: ValueNode) -> List[ValueNode]:
+
+        target_nodes = self._filter_target_nodes(node)
+
         return [
             value_node
-            for value_node in self.target_nodes
+            for value_node in target_nodes
             if value_node.name == node.name and node is not value_node
         ]
+
+    def _filter_target_nodes(self, node) -> List[ValueNode]:
+        """Filter target nodes to avoid links within the same maven file."""
+        artifact_name = node.id.split("::::")[1]
+
+        if "pom.xml" in artifact_name:
+            return list(
+                filter(
+                    lambda node: artifact_name not in node.id.split("::::")[1],
+                    self.target_nodes,
+                )
+            )
+
+        return self.target_nodes

--- a/src/cfgnet/linker/linker.py
+++ b/src/cfgnet/linker/linker.py
@@ -16,7 +16,7 @@
 """Package for linking nodes."""
 
 import abc
-from typing import List, Any, Optional, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 from cfgnet.linker.link import Link
 from cfgnet.linker.static_blacklist import StaticBlackList
 from cfgnet.network.nodes import ValueNode
@@ -31,38 +31,19 @@ class Linker(abc.ABC):
     def __init__(self):
         self.network: Optional["Network"] = None
         self.target_nodes: List = None
-        self._static_blacklist = StaticBlackList()
+        self.static_blacklist = StaticBlackList()
 
+    @abc.abstractmethod
     def create_links(self) -> None:
-        """
-        Call for each linker to create links based on a specific linker criterion.
+        """Call for each linker to create links based on a specific linker criterion."""
 
-        :param node: Node that has been added to the network
-        :return: None
-        """
-        self.target_nodes = self._find_target_nodes()
+    @abc.abstractmethod
+    def _find_target_nodes(self):
+        """Find all nodes for which a linker is_responsible."""
 
-        for node in self.target_nodes:
-            self._create_links(node)
-
-    def _create_links(self, node: Any) -> None:
-        """Create links using nodes for which the corresponding linker is responsible."""
-        # discard empty values
-        if not node.name:
-            return
-
-        # discard words from static blacklist
-        if self.network:
-            if self.network.cfg.enable_static_blacklist:
-                if node.name in self._static_blacklist.values:
-                    return
-
-        # find all matches with the given linker criterion
-        matches = self._find_matches(node)
-
-        # add link for all matches
-        for match in matches:
-            self._add_link(node, match)
+    @abc.abstractmethod
+    def _find_matches(self, node):
+        """Find all matches for node with a given linker criterion."""
 
     def _add_link(self, node_a: ValueNode, node_b: ValueNode):
         """
@@ -75,11 +56,3 @@ class Linker(abc.ABC):
         link = Link(node_a, node_b)
         if self.network:
             self.network.links.add(link)
-
-    @abc.abstractmethod
-    def _find_target_nodes(self):
-        """Find all nodes for which a linker is_responsible."""
-
-    @abc.abstractmethod
-    def _find_matches(self, node):
-        """Find all matches for node with a given linker criterion."""

--- a/tests/test_repos/maven_docker/0001-Add-Docker-and-maven-file.patch
+++ b/tests/test_repos/maven_docker/0001-Add-Docker-and-maven-file.patch
@@ -45,7 +45,7 @@ index 0000000..ddcc1c2
 +          <dependency>
 +            <groupId>mockito</groupId>
 +            <artifactId>mockito_artifact</artifactId>
-+            <version>3.7</version>
++            <version>5.9</version>
 +          </dependency>
 +
 +          <dependency>


### PR DESCRIPTION
In this PR, I revised the base and equality linker. Specifically, I added an abstract method to the base linker class that has to be implemented by each linker. Moreover, I filtered the target nodes for the equality linker to avoid links within the same maven file. This should avoid many false positives when analyzing repositories that use Maven. 