### PR TITLE
Add toml plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ click = "^8.0.3"
 graphviz = "^0.17"
 PyYAML = "^6.0"
 types-PyYAML = "^6.0.1"
+types-toml = "^0.10.1"
 
 [tool.poetry.dev-dependencies]
 black = { version = '*', allow-prereleases = true }

--- a/src/cfgnet/network/nodes.py
+++ b/src/cfgnet/network/nodes.py
@@ -173,7 +173,7 @@ class ValueNode(Node):
     def __init__(
         self, name: str, config_type: ConfigType = ConfigType.UNKNOWN
     ):
-        super().__init__(name)
+        super().__init__(str(name))
         self.config_type = config_type
 
     def __eq__(self, other):

--- a/src/cfgnet/plugins/file_type/toml_plugin.py
+++ b/src/cfgnet/plugins/file_type/toml_plugin.py
@@ -1,0 +1,89 @@
+# This file is part of the CfgNet module.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+
+import toml
+
+from cfgnet.network.nodes import ArtifactNode, OptionNode, ValueNode
+from cfgnet.plugins.plugin import Plugin
+
+
+class TomlPlugin(Plugin):
+    def __init__(self):
+        super().__init__("toml")
+
+    def _parse_config_file(self, abs_file_path, rel_file_path, root):
+
+        artifact = ArtifactNode(
+            name=os.path.basename(abs_file_path),
+            file_path=abs_file_path,
+            rel_file_path=rel_file_path,
+            concept_name=self.concept_name,
+            project_root=root,
+        )
+
+        with open(abs_file_path, "r", encoding="utf-8") as file:
+            line_number_dict = {}
+            lineno = 1
+            for line in file:
+                line = line.strip()
+                if len(line) > 0:
+                    line_number_dict[line] = lineno
+                lineno += 1
+
+        with open(abs_file_path, "r", encoding="utf-8") as file:
+            data = toml.load(file)
+            self._iter_data(data, line_number_dict, artifact)
+
+        return artifact
+
+    def is_responsible(self, abs_file_path):
+        if abs_file_path.endswith(".toml"):
+            return True
+
+        return False
+
+    def _iter_data(self, data, line_number_dict, parent):
+        for argument, value in data.items():
+            lineno = None
+
+            for line in line_number_dict.keys():
+                if argument in line:
+                    lineno = line_number_dict[line]
+                    del line_number_dict[line]
+                    break
+
+            option = OptionNode(argument, lineno)
+            parent.add_child(option)
+
+            if isinstance(value, dict):
+                self._iter_data(value, line_number_dict, option)
+            elif isinstance(value, list):
+                index = 0
+                for entry in value:
+                    if isinstance(entry, dict):
+                        virtual_option = OptionNode(
+                            option.name + "_" + str(index), lineno
+                        )
+                        option.add_child(virtual_option)
+                        self._iter_data(
+                            entry, line_number_dict, virtual_option
+                        )
+                        index += 1
+                    else:
+                        option.add_child(ValueNode(entry))
+            else:
+                option.add_child(ValueNode(value))

--- a/src/cfgnet/plugins/plugin_manager.py
+++ b/src/cfgnet/plugins/plugin_manager.py
@@ -23,6 +23,7 @@ from cfgnet.plugins.concept.travis_plugin import TravisPlugin
 from cfgnet.plugins.concept.docker_compose_plugin import DockerComposePlugin
 from cfgnet.plugins.file_type.configparser_plugin import ConfigParserPlugin
 from cfgnet.plugins.file_type.yaml_plugin import YAMLPlugin
+from cfgnet.plugins.file_type.toml_plugin import TomlPlugin
 
 
 class PluginManager:
@@ -36,7 +37,11 @@ class PluginManager:
         TravisPlugin(),
     ]
 
-    file_type_plugins: List[Plugin] = [ConfigParserPlugin(), YAMLPlugin()]
+    file_type_plugins: List[Plugin] = [
+        ConfigParserPlugin(),
+        YAMLPlugin(),
+        TomlPlugin(),
+    ]
 
     @staticmethod
     def get_plugins() -> List:

--- a/tests/cfgnet/plugins/file_type/test_toml_plugin.py
+++ b/tests/cfgnet/plugins/file_type/test_toml_plugin.py
@@ -1,0 +1,80 @@
+# This file is part of the CfgNet module.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+
+import pytest
+
+from cfgnet.plugins.file_type.toml_plugin import TomlPlugin
+from tests.utility.id_creator import make_id
+
+
+@pytest.fixture(name="get_plugin")
+def get_plugin_():
+    plugin = TomlPlugin()
+    return plugin
+
+
+def test_is_responsible(get_plugin):
+    toml_plugin = get_plugin
+
+    toml_file = toml_plugin.is_responsible("/path/to/file.toml")
+    no_toml_file = toml_plugin.is_responsible("/path/to/pom.xml")
+
+    assert toml_file
+    assert not no_toml_file
+
+
+def test_parse_toml_file(get_plugin):
+    toml_plugin = get_plugin
+    toml_file = os.path.abspath("tests/files/test.toml")
+
+    artifact = toml_plugin.parse_file(toml_file, "test.toml")
+    nodes = artifact.get_nodes()
+    ids = {node.id for node in nodes}
+
+    assert artifact is not None
+    assert len(nodes) == 8
+
+    assert make_id("test.toml", "file", "test.toml") in ids
+    assert make_id("test.toml", "tool", "poetry", "name", "cfgnet") in ids
+    assert make_id("test.toml", "tool", "poetry", "version", "v1.1.0") in ids
+    assert make_id("test.toml", "tool", "poetry", "keywords", "config") in ids
+    assert make_id("test.toml", "dependencies", "python", "^3.6") in ids
+    assert make_id("test.toml", "dependencies", "gitpython", "^3.0") in ids
+    assert (
+        make_id(
+            "test.toml",
+            "tool",
+            "poetry",
+            "packages",
+            "packages_0",
+            "include",
+            "cfgnet",
+        )
+        in ids
+    )
+    assert (
+        make_id(
+            "test.toml",
+            "tool",
+            "poetry",
+            "packages",
+            "packages_0",
+            "from",
+            "src",
+        )
+        in ids
+    )

--- a/tests/cfgnet/plugins/test_plugin_manager.py
+++ b/tests/cfgnet/plugins/test_plugin_manager.py
@@ -19,7 +19,7 @@ from cfgnet.plugins.plugin_manager import PluginManager
 def test_get_all_plugins():
     all_plugins = PluginManager.get_plugins()
 
-    assert len(set(all_plugins)) == 7
+    assert len(set(all_plugins)) == 8
 
 
 def test_get_responsible_plugin():
@@ -37,6 +37,7 @@ def test_get_responsible_plugin():
     properties_plugin = PluginManager.get_responsible_plugin(
         "path/to/applications.properties"
     )
+    toml_plugin = PluginManager.get_responsible_plugin("path/to/test.toml")
 
     assert docker_plugin.concept_name == "docker"
     assert maven_plugin.concept_name == "maven"
@@ -46,3 +47,4 @@ def test_get_responsible_plugin():
     assert yaml_plugin.concept_name == "yaml"
     assert ini_plugin.concept_name == "configparser"
     assert properties_plugin.concept_name == "configparser"
+    assert toml_plugin.concept_name == "toml"

--- a/tests/files/test.toml
+++ b/tests/files/test.toml
@@ -1,0 +1,11 @@
+[tool.poetry]
+name = 'cfgnet'
+version = 'v1.1.0'
+keywords=['config']
+packages = [
+    { include = 'cfgnet', from = 'src' },
+]
+
+[dependencies]
+python = '^3.6'
+gitpython = '^3.0'


### PR DESCRIPTION
Similar to the yaml plugins, it is not straightforward to add configuration types into parsing process, since we do not know what configuration we are actually parsing.