### PR TITLE
Open log file only once

### DIFF
--- a/src/cfgnet/launcher.py
+++ b/src/cfgnet/launcher.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 import click
 
-from cfgnet.utility.logger import configure_console_logger
+from cfgnet.utility import logger
 from cfgnet.network.network import Network
 from cfgnet.network.network_configuration import NetworkConfiguration
 from cfgnet.launcher_configuration import LauncherConfiguration
@@ -44,7 +44,7 @@ add_disable_linker_option = click.option(
 )
 def main(verbose: bool):
     LauncherConfiguration.verbose = verbose
-    configure_console_logger(verbose=verbose)
+    logger.configure_console_logger(verbose=verbose)
 
 
 @main.command()
@@ -73,6 +73,7 @@ def init(
         enabled_linkers=list(set(enable_linker) - set(disable_linker)),
     )
     LinkerManager.set_enabled_linkers(network_configuration.enabled_linkers)
+    logger.configure_repo_logger(network_configuration.logfile_path())
 
     start = time.time()
 
@@ -93,6 +94,7 @@ def validate(project_root: str):
     start = time.time()
 
     ref_network = Network.load_network(project_root=project_root)
+    logger.configure_repo_logger(ref_network.cfg.logfile_path())
 
     # TODO Network should configure LinkerManager with list of enabled linkers
 
@@ -149,6 +151,7 @@ def analyze(
         enabled_linkers=list(set(enable_linker) - set(disable_linker)),
     )
     LinkerManager.set_enabled_linkers(network_configuration.enabled_linkers)
+    logger.configure_repo_logger(network_configuration.logfile_path())
 
     enabled_linkers = set(enable_linker) - set(disable_linker)
     LinkerManager.set_enabled_linkers(enabled_linkers)
@@ -183,6 +186,7 @@ def export(
     LauncherConfiguration.export_visualize_dot = visualize_dot
 
     network = Network.load_network(project_root)
+    logger.configure_repo_logger(network.cfg.logfile_path())
 
     if LauncherConfiguration.export_visualize_dot:
 

--- a/src/cfgnet/network/network.py
+++ b/src/cfgnet/network/network.py
@@ -24,7 +24,6 @@ import pickle
 from typing import List, Set, Any, Optional, Callable, Tuple
 from collections import defaultdict
 from cfgnet.vcs.git import Git
-from cfgnet.utility.logger import configure_repo_logger
 from cfgnet.plugins.plugin_manager import PluginManager
 from cfgnet.linker.linker_manager import LinkerManager
 from cfgnet.conflicts.conflict_detector import ConflictDetector
@@ -60,11 +59,6 @@ class Network:
 
         if not os.path.isdir(self.cfg.data_dir_path()):
             os.makedirs(self.cfg.data_dir_path())
-
-        log_file_path = os.path.join(
-            self.cfg.data_dir_path(), f"{self.project_name}.log"
-        )
-        configure_repo_logger(log_file_path)
 
         IgnoreFile.configure(cfg.ignorefile_path())
 
@@ -276,7 +270,7 @@ class Network:
         repo = Git(project_root=cfg.project_root_abs)
         tracked_files: Set[str] = set(repo.get_tracked_files())
 
-        project_name = os.path.basename(cfg.project_root_abs)
+        project_name = cfg.project_name()
         root = ProjectNode(name=project_name, root_dir=cfg.project_root_abs)
         network = Network(project_name=project_name, root=root, cfg=cfg)
 

--- a/src/cfgnet/network/network_configuration.py
+++ b/src/cfgnet/network/network_configuration.py
@@ -27,3 +27,9 @@ class NetworkConfiguration:
 
     def ignorefile_path(self):
         return os.path.join(self.data_dir_path(), "ignore")
+
+    def project_name(self):
+        return os.path.basename(self.project_root_abs)
+
+    def logfile_path(self):
+        return os.path.join(self.data_dir_path(), f"{self.project_name()}.log")

--- a/src/cfgnet/utility/logger.py
+++ b/src/cfgnet/utility/logger.py
@@ -14,6 +14,7 @@
 # this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
+import os
 
 # basic logging formatter
 log_formatter = logging.Formatter(
@@ -41,6 +42,9 @@ def configure_console_logger(verbose: bool):
 
 def configure_repo_logger(repo_log_file_path: str):
     """Configure logging to per-repo logfile."""
+    log_dir = os.path.dirname(repo_log_file_path)
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir)
     repo_logging_handler = logging.FileHandler(repo_log_file_path)
     repo_logging_handler.setLevel(logging.DEBUG)
     repo_logging_handler.setFormatter(log_formatter)


### PR DESCRIPTION
Fixes #63

Example command to see how many files are open:
```
poetry run cfgnet analyze ~/git/pydriller & while 1; do; lsof -p $! | wc -l && sleep 1; done
```

This obviously improves performance quite a bit, on pydriller cloned with `--depth=200`, I get:
old tool: 28.3 sec
new tool, w/o fix: 79.5 sec
new tool w/ fix: 39.2 sec