### PR TITLE
Allow empty values but they need the str tag

### DIFF
--- a/src/cfgnet/plugins/file_type/yaml_plugin.py
+++ b/src/cfgnet/plugins/file_type/yaml_plugin.py
@@ -114,8 +114,12 @@ class YAMLPlugin(Plugin):
 
     @staticmethod
     def _parse_scalar_node(node, parent):
-        if node.value != "":
-            value = ValueNode(node.value)
+        # empty values are possible, but need str tag
+        if node.value != "" or (
+            node.value == "" and node.tag == "tag:yaml.org,2002:str"
+        ):
+            name = node.value if node.value != "" else ""
+            value = ValueNode(name=name)
             if isinstance(parent, ArtifactNode):
                 option = OptionNode("unnamed_option", node.start_mark.line + 1)
                 parent.add_child(option)

--- a/tests/cfgnet/plugins/file_type/test_yaml_plugin.py
+++ b/tests/cfgnet/plugins/file_type/test_yaml_plugin.py
@@ -51,7 +51,7 @@ def test_parse_yaml_file(get_plugin):
     ids = {node.id for node in nodes}
 
     assert artifact is not None
-    assert len(nodes) == 9
+    assert len(nodes) == 10
     assert make_id("test.yaml", "file", "test.yaml") in ids
     assert make_id("test.yaml", "test.yaml_0", "name", "Port") in ids
     assert make_id("test.yaml", "test.yaml_0", "args", "number", "8000") in ids
@@ -65,3 +65,4 @@ def test_parse_yaml_file(get_plugin):
         make_id("test.yaml", "test.yaml_1", "copy", "dest", "./tmp.sh") in ids
     )
     assert make_id("test.yaml", "test.yaml_2", "runs-on", "matrix.os") in ids
+    assert make_id("test.yaml", "test.yaml_3", "test", "empty", "") in ids

--- a/tests/files/test.yaml
+++ b/tests/files/test.yaml
@@ -10,3 +10,7 @@
   ignore_errors: true
 
 - runs-on: {{ matrix.os }}
+
+- test:
+    empty:
+      - ''


### PR DESCRIPTION
Fix #73 and might fix #77 as well.

We allow now empty values if they appear in a yaml file, however the need the ``str`` tag. For more information look into the [yaml docs](https://pyyaml.org/wiki/PyYAMLDocumentation) under ``YAML tags and Python types``.

Before we did not allow empty values, which made it possible that option had no children. 