### PR TITLE
Handle blackslashes like the json library

### DIFF
--- a/src/cfgnet/plugins/concept/nodejs_plugin.py
+++ b/src/cfgnet/plugins/concept/nodejs_plugin.py
@@ -60,6 +60,7 @@ class NodejsPlugin(Plugin):
                 lineno = 1
                 for line in json_file:
                     line = line.strip()
+                    line = line.replace("\\\\", "\\")
                     if len(line) > 0:
                         line_number_dict[line] = lineno
                     lineno += 1

--- a/tests/cfgnet/plugins/concept/test_nodejs_plugin.py
+++ b/tests/cfgnet/plugins/concept/test_nodejs_plugin.py
@@ -51,7 +51,7 @@ def test_parsing_package_json_file(get_plugin):
     ids = {node.id for node in nodes}
 
     assert artifact is not None
-    assert len(nodes) == 9
+    assert len(nodes) == 10
 
     assert make_id("package.json", "file", "package.json") in ids
     assert make_id("package.json", "name", "node-js-sample") in ids
@@ -73,52 +73,51 @@ def test_parsing_package_json_file(get_plugin):
         )
         in ids
     )
+    pattern = "^.+\module\css$"  # noqa: W605
+    assert make_id("package.json", pattern, "Test") in ids
 
-    def test_config_types():
-        nodejs_plugin = get_plugin
-        file = os.path.abspath("tests/files/package.json")
 
-        artifact = nodejs_plugin.parse_file(file, "package.json")
-        nodes = artifact.get_nodes()
+def test_config_types(get_plugin):
+    nodejs_plugin = get_plugin
+    file = os.path.abspath("tests/files/package.json")
 
-        url_node = next(
-            filter(
-                lambda x: x.id
-                == make_id(
-                    "package.json",
-                    "repo",
-                    "url",
-                    "https://github.com/example/example",
-                ),
-                nodes,
-            )
-        )
-        dep_node = next(
-            filter(
-                lambda x: x.id
-                == make_id(
-                    "package.json", "dependencies", "express", "^4.13.3"
-                ),
-                nodes,
-            )
-        )
-        script_node = next(
-            filter(
-                lambda x: x.id
-                == make_id(
-                    "package.json", "scripts", "start", "node index.js"
-                ),
-                nodes,
-            )
-        )
-        file_node = next(
-            filter(
-                lambda x: x.id == make_id("package.json", "main", "index.js"),
-                nodes,
-            )
-        )
+    artifact = nodejs_plugin.parse_file(file, "package.json")
+    nodes = artifact.get_nodes()
 
-        assert url_node.config_type == ConfigType.URL
-        assert dep_node.config_type == ConfigType.VERSION_NUMBER
-        assert script_node.config_type == ConfigType.COMMAND
-        assert file_node.config_type == ConfigType.FILEPATH
+    url_node = next(
+        filter(
+            lambda x: x.id
+            == make_id(
+                "package.json",
+                "repository",
+                "url",
+                "https://github.com/example/example",
+            ),
+            nodes,
+        )
+    )
+    dep_node = next(
+        filter(
+            lambda x: x.id
+            == make_id("package.json", "dependencies", "express", "^4.13.3"),
+            nodes,
+        )
+    )
+    script_node = next(
+        filter(
+            lambda x: x.id
+            == make_id("package.json", "scripts", "start", "node index.js"),
+            nodes,
+        )
+    )
+    file_node = next(
+        filter(
+            lambda x: x.id == make_id("package.json", "main", "index.js"),
+            nodes,
+        )
+    )
+
+    assert url_node.config_type == ConfigType.URL
+    assert dep_node.config_type == ConfigType.VERSION_NUMBER
+    assert script_node.config_type == ConfigType.COMMAND
+    assert file_node.config_type == ConfigType.FILEPATH

--- a/tests/files/package.json
+++ b/tests/files/package.json
@@ -20,5 +20,6 @@
   "devDependencies": {
 	"nodemon": "^1.1.1"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "^.+\\module\\css$": "Test"
 }


### PR DESCRIPTION
Fix #74 and #78.

When creating the dictionary, which is used later to identify the line number, we avoid double backslashes by replacing them with one backslash.

Apart from that, one test was too deeply indented and was never executed.