### PR TITLE
Catch TomlDecodeError when parsing toml files

### DIFF
--- a/src/cfgnet/plugins/file_type/toml_plugin.py
+++ b/src/cfgnet/plugins/file_type/toml_plugin.py
@@ -14,9 +14,9 @@
 # this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
-
+import logging
 import toml
-
+from toml import TomlDecodeError
 from cfgnet.network.nodes import ArtifactNode, OptionNode, ValueNode
 from cfgnet.plugins.plugin import Plugin
 
@@ -45,8 +45,14 @@ class TomlPlugin(Plugin):
                 lineno += 1
 
         with open(abs_file_path, "r", encoding="utf-8") as file:
-            data = toml.load(file)
-            self._iter_data(data, line_number_dict, artifact)
+            try:
+                data = toml.load(file)
+                self._iter_data(data, line_number_dict, artifact)
+
+            except TomlDecodeError as error:
+                logging.warning(
+                    "Invalid Toml file %s: %s", abs_file_path, error
+                )
 
         return artifact
 


### PR DESCRIPTION
Fix #91 

Fixing the TomlDecodeError should also fix the other errors.

I added to the Toml plugin a new `try-except` block that catches the `TomlDecodeError` when parsing an invalid toml file.