### PR TITLE
Catch IndexError when trying to get last parsed command

### DIFF
--- a/src/cfgnet/plugins/concept/docker_plugin.py
+++ b/src/cfgnet/plugins/concept/docker_plugin.py
@@ -61,10 +61,13 @@ def parse_string(content: str) -> List[Command]:
 
         # if there is no cmd, add line to the last created cmd
         if command not in COMMANDS:
-            last_cmd = data[-1]
-            if last_cmd.cmd == "env":
-                values = parse_env(line)
-                last_cmd.value += values
+            try:
+                last_cmd = data[-1]
+                if last_cmd.cmd == "env":
+                    values = parse_env(line)
+                    last_cmd.value += values
+                    continue
+            except IndexError:
                 continue
 
         # parse env command


### PR DESCRIPTION
The parsing of dockerfiles failed, for instance, during the analysis of [moby](https://github.com/moby/moby), due to an IndexError.
I added a `try-except` block to catch the IndexError when we try to get the last parsed command. 