### PR TITLE
Combine option and value name for version numbers in maven and node_j…

### DIFF
--- a/src/cfgnet/plugins/concept/nodejs_plugin.py
+++ b/src/cfgnet/plugins/concept/nodejs_plugin.py
@@ -118,15 +118,27 @@ class NodejsPlugin(Plugin):
                         ),
                     )
                     parent.add_child(virtual_option)
+
+                    name = (
+                        f"{parent.name}:{item}"
+                        if self.current_config_type
+                        == ConfigType.VERSION_NUMBER
+                        else item
+                    )
+
                     value = ValueNode(
-                        name=item, config_type=self.current_config_type
+                        name=name, config_type=self.current_config_type
                     )
                     virtual_option.add_child(value)
 
         else:
-            value = ValueNode(
-                name=json_object, config_type=self.current_config_type
+            name = (
+                f"{parent.name}:{json_object}"
+                if self.current_config_type == ConfigType.VERSION_NUMBER
+                else json_object
             )
+            value = ValueNode(name=name, config_type=self.current_config_type)
+
             if not isinstance(parent, ArtifactNode):
                 parent.add_child(value)
 
@@ -169,4 +181,6 @@ class NodejsPlugin(Plugin):
             return ConfigType.EMAIL
         if option_name in ("repository", "author", "funding", "type"):
             return ConfigType.UNKNOWN
+        if option_name == "license":
+            return ConfigType.LICENSE
         return self.current_config_type

--- a/tests/cfgnet/network/test_network.py
+++ b/tests/cfgnet/network/test_network.py
@@ -87,7 +87,7 @@ def test_enable_internal_links(get_config):
         "target/example-app-1.0.jar",
         "pom.xml",
         "builder",
-        "5.9",
+        "version:5.9",
     }
 
     link_targets = {

--- a/tests/cfgnet/plugins/concept/test_maven_plugin.py
+++ b/tests/cfgnet/plugins/concept/test_maven_plugin.py
@@ -55,7 +55,7 @@ def test_parse_file(get_plugin):
             "dependencies",
             "dependency_apple/apple_artifact",
             "version",
-            "apple_version",
+            "version:apple_version",
         )
         in ids
     )
@@ -89,13 +89,15 @@ def test_parse_file(get_plugin):
         make_id("pom.xml", "project", "modules", "module", "registry") in ids
     )
     assert make_id("pom.xml", "project", "port", "8000") in ids
-    assert make_id("pom.xml", "project", "modelVersion", "4.0.0") in ids
+    assert (
+        make_id("pom.xml", "project", "modelVersion", "modelVersion:4.0.0")
+        in ids
+    )
     assert make_id("pom.xml", "project", "packaging", "jar") in ids
     assert make_id("pom.xml", "file", "pom.xml") in ids
     assert make_id("pom.xml", "project", "groupId", "com.example.apps") in ids
     assert make_id("pom.xml", "project", "artifactId", "my-cool-app") in ids
-    assert make_id("pom.xml", "project", "version", "42") in ids
-    assert make_id("pom.xml", "project", "version", "42") in ids
+    assert make_id("pom.xml", "project", "version", "version:42") in ids
     assert (
         make_id("pom.xml", "ExecutableName", "target/my-cool-app-42.jar")
         in ids

--- a/tests/cfgnet/plugins/concept/test_nodejs_plugin.py
+++ b/tests/cfgnet/plugins/concept/test_nodejs_plugin.py
@@ -55,14 +55,18 @@ def test_parsing_package_json_file(get_plugin):
 
     assert make_id("package.json", "file", "package.json") in ids
     assert make_id("package.json", "name", "node-js-sample") in ids
-    assert make_id("package.json", "version", "0.2.0") in ids
+    assert make_id("package.json", "version", "version:0.2.0") in ids
     assert make_id("package.json", "main", "index.js") in ids
     assert make_id("package.json", "license", "ISC") in ids
 
     assert make_id("package.json", "scripts", "start", "node index.js") in ids
-    assert make_id("package.json", "dependencies", "express", "^4.13.3") in ids
     assert (
-        make_id("package.json", "devDependencies", "nodemon", "^1.1.1") in ids
+        make_id("package.json", "dependencies", "express", "express:^4.13.3")
+        in ids
+    )
+    assert (
+        make_id("package.json", "devDependencies", "nodemon", "nodemon:^1.1.1")
+        in ids
     )
     assert (
         make_id(
@@ -99,7 +103,9 @@ def test_config_types(get_plugin):
     dep_node = next(
         filter(
             lambda x: x.id
-            == make_id("package.json", "dependencies", "express", "^4.13.3"),
+            == make_id(
+                "package.json", "dependencies", "express", "express:^4.13.3"
+            ),
             nodes,
         )
     )


### PR DESCRIPTION
Fix #96 

For value nodes with the type `ConfigType.VERSION_NUMBER` in the node_js and maven plugin, we now create the name of the value node by using the pattern `<option.name>:<value>`. For example, see the code snippet below:
```
 "devDependencies": {
    "mocha": "9",
  },
```
In this example, we would create the following node: `....::::devDependencies::::mocha::::mocha:9`