### PR TITLE
Append config type to option nodes so that added nodes inherit the type

### DIFF
--- a/src/cfgnet/network/nodes.py
+++ b/src/cfgnet/network/nodes.py
@@ -127,20 +127,28 @@ class ArtifactNode(Node):
 
     def _add_file_name_option(self) -> None:
         """Add default option to the artifact node."""
-        option = OptionNode(name="file", location="file_path")
+        option = OptionNode(
+            name="file", location="file_path", config_type=ConfigType.PATH
+        )
         self.add_child(option)
-        value = ValueNode(name=self.rel_file_path, config_type=ConfigType.PATH)
+        value = ValueNode(name=self.rel_file_path)
         option.add_child(value)
 
 
 class OptionNode(Node):
     """Option nodes refer to commands or lines of code in an artifact."""
 
-    def __init__(self, name: str, location: str):
+    def __init__(
+        self,
+        name: str,
+        location: str,
+        config_type: ConfigType = ConfigType.UNKNOWN,
+    ):
         super().__init__(name)
         self.display_option_id: str = name
         self.location: str = location
         self.prevalue_node: bool = False
+        self.config_type = config_type
 
     def __str__(self):
         return self.id + "(location: " + str(self.location) + ")"
@@ -161,17 +169,18 @@ class OptionNode(Node):
         if isinstance(node, ValueNode):
             self.prevalue_node = True
 
+        if node.config_type == ConfigType.UNKNOWN:
+            node.config_type = self.config_type
+
         super().add_child(node)
 
 
 class ValueNode(Node):
     """Value nodes represent actual parameters associated to an option node."""
 
-    def __init__(
-        self, name: str, config_type: ConfigType = ConfigType.UNKNOWN
-    ):
+    def __init__(self, name: str):
         super().__init__(str(name))
-        self.config_type = config_type
+        self.config_type = ConfigType.UNKNOWN
 
     def __eq__(self, other):
         return self.name == other.name

--- a/src/cfgnet/plugins/concept/docker_compose_plugin.py
+++ b/src/cfgnet/plugins/concept/docker_compose_plugin.py
@@ -35,14 +35,14 @@ class DockerComposePlugin(YAMLPlugin):
         if node.value != "":
             match = self.ports.match(node.value)
             if match is not None:
-                port_in = ValueNode(
-                    name=match.group("in"), config_type=ConfigType.PORT
+                port_in = ValueNode(name=match.group("in"))
+                port_out = ValueNode(name=match.group("out"))
+                option_port_in = OptionNode(
+                    "in", node.start_mark.line + 1, ConfigType.PORT
                 )
-                port_out = ValueNode(
-                    name=match.group("out"), config_type=ConfigType.PORT
+                option_port_out = OptionNode(
+                    "out", node.start_mark.line + 1, ConfigType.PORT
                 )
-                option_port_in = OptionNode("in", node.start_mark.line + 1)
-                option_port_out = OptionNode("out", node.start_mark.line + 1)
                 parent.add_child(option_port_in)
                 parent.add_child(option_port_out)
                 option_port_in.add_child(port_in)

--- a/tests/cfgnet/config_types/test_config_types.py
+++ b/tests/cfgnet/config_types/test_config_types.py
@@ -15,6 +15,44 @@
 
 
 from cfgnet.config_types.config_types import ConfigType
+from cfgnet.network.nodes import OptionNode, ValueNode
+
+
+def test_config_types_option_value():
+    option_port = OptionNode("port", "1", ConfigType.PORT)
+    port = ValueNode("8000")
+    option_port.add_child(port)
+
+    assert option_port.config_type == ConfigType.PORT
+    assert port.config_type == ConfigType.PORT
+
+
+def test_config_types_nested_option():
+
+    option_path = OptionNode("path", "1", ConfigType.PATH)
+    nested_option = OptionNode("port", "2", ConfigType.PORT)
+    option_path.add_child(nested_option)
+    port = ValueNode("8000")
+    nested_option.add_child(port)
+
+    assert option_path.config_type == ConfigType.PATH
+    assert nested_option.config_type == ConfigType.PORT
+    assert port.config_type == ConfigType.PORT
+
+
+def test_config_types_nested_options_unknown():
+
+    option_dependency = OptionNode(
+        "dependencies", "1", ConfigType.VERSION_NUMBER
+    )
+    nested_option = OptionNode("pylint", "2")
+    option_dependency.add_child(nested_option)
+    version = ValueNode("3.2.1")
+    nested_option.add_child(version)
+
+    assert option_dependency.config_type == ConfigType.VERSION_NUMBER
+    assert nested_option.config_type == ConfigType.VERSION_NUMBER
+    assert version.config_type == ConfigType.VERSION_NUMBER
 
 
 def test_file_paths():

--- a/tests/cfgnet/linker/test_equality_linker.py
+++ b/tests/cfgnet/linker/test_equality_linker.py
@@ -15,22 +15,36 @@
 
 from cfgnet.linker.equality_linker import EqualityLinker
 from cfgnet.config_types.config_types import ConfigType
-from cfgnet.network.nodes import ValueNode
+from cfgnet.network.nodes import OptionNode, ValueNode
 
 
 def test_check_config_types():
     linker = EqualityLinker()
 
-    port_node_a = ValueNode(name="8000", config_type=ConfigType.PORT)
-    port_node_b = ValueNode(name="8000", config_type=ConfigType.PORT)
-    unknown_node_a = ValueNode(name="unknown", config_type=ConfigType.UNKNOWN)
-    unknown_node_b = ValueNode(name="unknown", config_type=ConfigType.UNKNOWN)
-    path_node = ValueNode(name="path", config_type=ConfigType.PATH)
+    option_port_a = OptionNode("port_a", "1", ConfigType.PORT)
+    port_a = ValueNode(name="8000")
+    option_port_a.add_child(port_a)
 
-    same_type = linker._check_config_types(port_node_a, port_node_b)
-    only_one_unknown = linker._check_config_types(port_node_a, unknown_node_a)
-    both_unknown = linker._check_config_types(unknown_node_a, unknown_node_b)
-    different_types = linker._check_config_types(port_node_a, path_node)
+    option_port_b = OptionNode("port_b", "2", ConfigType.PORT)
+    port_b = ValueNode(name="8000")
+    option_port_b.add_child(port_b)
+
+    option_unknown_a = OptionNode("unknown_a", "3", ConfigType.UNKNOWN)
+    unknown_a = ValueNode(name="unknown")
+    option_unknown_a.add_child(unknown_a)
+
+    option_unknown_b = OptionNode("unknown_a", "4", ConfigType.UNKNOWN)
+    unknown_b = ValueNode(name="unknown_b")
+    option_unknown_b.add_child(unknown_b)
+
+    option_path = OptionNode("path", "4", ConfigType.PATH)
+    path = ValueNode(name="path")
+    option_path.add_child(path)
+
+    same_type = linker._check_config_types(port_a, port_b)
+    only_one_unknown = linker._check_config_types(port_a, unknown_a)
+    both_unknown = linker._check_config_types(unknown_a, unknown_b)
+    different_types = linker._check_config_types(port_a, path)
 
     assert same_type
     assert only_one_unknown


### PR DESCRIPTION
I changed how we add config types to specific node. Now, we add the type already to option nodes. All nodes that are added to the option node inherit its type.