### PR TITLE
Add options to only allow the use of concept plugins

### DIFF
--- a/src/cfgnet/launcher.py
+++ b/src/cfgnet/launcher.py
@@ -51,6 +51,7 @@ def main(verbose: bool):
 @click.option("-b", "--enable-static-blacklist", is_flag=True)
 @click.option("-d", "--enable-dynamic-blacklist", is_flag=True)
 @click.option("-i", "--enable-internal-links", is_flag=True)
+@click.option("-c", "--only-concept-plugins", is_flag=False)
 @add_project_root_argument
 @add_enable_linker_option
 @add_disable_linker_option
@@ -58,6 +59,7 @@ def init(
     enable_static_blacklist: bool,
     enable_dynamic_blacklist: bool,
     enable_internal_links: bool,
+    only_concept_plugins: bool,
     project_root: str,
     enable_linker: List[str],
     disable_linker: List[str],
@@ -70,6 +72,7 @@ def init(
         project_root_abs=os.path.abspath(project_root),
         enable_static_blacklist=enable_static_blacklist,
         enable_dynamic_blacklist=enable_dynamic_blacklist,
+        only_concept_plugins=only_concept_plugins,
         enable_internal_links=enable_internal_links,
         enabled_linkers=list(set(enable_linker) - set(disable_linker)),
     )
@@ -129,6 +132,7 @@ def validate(project_root: str):
 @click.option("-b", "--enable-static-blacklist", is_flag=True)
 @click.option("-d", "--enable-dynamic-blacklist", is_flag=True)
 @click.option("-i", "--enable-internal-links", is_flag=True)
+@click.option("-c", "--only-concept-plugins", is_flag=False)
 @add_project_root_argument
 @add_enable_linker_option
 @add_disable_linker_option
@@ -136,6 +140,7 @@ def analyze(
     enable_static_blacklist: bool,
     enable_dynamic_blacklist: bool,
     enable_internal_links: bool,
+    only_concept_plugins: bool,
     project_root: str,
     enable_linker: List[str],
     disable_linker: List[str],
@@ -149,6 +154,7 @@ def analyze(
         project_root_abs=os.path.abspath(project_root),
         enable_static_blacklist=enable_static_blacklist,
         enable_dynamic_blacklist=enable_dynamic_blacklist,
+        only_concept_plugins=only_concept_plugins,
         enable_internal_links=enable_internal_links,
         enabled_linkers=list(set(enable_linker) - set(disable_linker)),
     )

--- a/src/cfgnet/network/network.py
+++ b/src/cfgnet/network/network.py
@@ -273,10 +273,13 @@ class Network:
         network = Network(project_name=project_name, root=root, cfg=cfg)
 
         tracked_files = IgnoreFile.filter(tracked_files)
+        plugins = PluginManager.get_plugins(cfg.only_concept_plugins)
 
         for file in sorted(tracked_files):
             abs_file_path = os.path.join(cfg.project_root_abs, file)
-            plugin = PluginManager.get_responsible_plugin(abs_file_path)
+            plugin = PluginManager.get_responsible_plugin(
+                plugins, abs_file_path
+            )
 
             if plugin:
                 try:

--- a/src/cfgnet/network/network_configuration.py
+++ b/src/cfgnet/network/network_configuration.py
@@ -11,6 +11,8 @@ class NetworkConfiguration:
     enable_static_blacklist: bool
     enable_dynamic_blacklist: bool
     enable_internal_links: bool
+    # Only allow the use of concept plugins
+    only_concept_plugins: bool = False
     # Path to CfgNet data directory relative to project_root
     cfgnet_path_rel: str = ".cfgnet"
     # List of names of enabled linkers

--- a/src/cfgnet/plugins/plugin_manager.py
+++ b/src/cfgnet/plugins/plugin_manager.py
@@ -50,19 +50,24 @@ class PluginManager:
     ]
 
     @staticmethod
-    def get_plugins() -> List:
+    def get_plugins(only_concept_plugins: bool = False) -> List:
         """Return all plugins except vcs plugins."""
+        if only_concept_plugins:
+            return PluginManager.concept_plugins
+
         return PluginManager.concept_plugins + PluginManager.file_type_plugins
 
     @staticmethod
-    def get_responsible_plugin(artifact_path: str) -> Optional[Plugin]:
+    def get_responsible_plugin(
+        plugins: List[Plugin], artifact_path: str
+    ) -> Optional[Plugin]:
         """
         Identify plugin that is responsible for an artifact.
 
         :param artifact_path: Absolute path to the artifact
         :return: Responsible plugin or None if there is no such plugin
         """
-        for plugin in PluginManager.get_plugins():
+        for plugin in plugins:
             if plugin.is_responsible(artifact_path):
                 return plugin
 

--- a/tests/cfgnet/plugins/test_plugin_manager.py
+++ b/tests/cfgnet/plugins/test_plugin_manager.py
@@ -18,34 +18,50 @@ from cfgnet.plugins.plugin_manager import PluginManager
 
 def test_get_all_plugins():
     all_plugins = PluginManager.get_plugins()
+    concept_plugins = PluginManager.get_plugins(only_concept_plugins=True)
 
-    assert len(set(all_plugins)) == 11
+    assert len(all_plugins) == 11
+    assert len(concept_plugins) == 8
 
 
 def test_get_responsible_plugin():
-    docker_plugin = PluginManager.get_responsible_plugin("path/to/Dockerfile")
-    maven_plugin = PluginManager.get_responsible_plugin("path/to/pom.xml")
+    plugins = PluginManager.get_plugins()
+
+    docker_plugin = PluginManager.get_responsible_plugin(
+        plugins, "path/to/Dockerfile"
+    )
+    maven_plugin = PluginManager.get_responsible_plugin(
+        plugins, "path/to/pom.xml"
+    )
     nodejs_plugin = PluginManager.get_responsible_plugin(
-        "path/to/package.json"
+        plugins, "path/to/package.json"
     )
     docker_compose_plugin = PluginManager.get_responsible_plugin(
-        "path/to/docker-compose.yml"
+        plugins, "path/to/docker-compose.yml"
     )
-    travis_plugin = PluginManager.get_responsible_plugin("path/to/.travis.yml")
-    yaml_plugin = PluginManager.get_responsible_plugin("path/to/test.yaml")
-    ini_plugin = PluginManager.get_responsible_plugin("path/to/tox.ini")
+    travis_plugin = PluginManager.get_responsible_plugin(
+        plugins, "path/to/.travis.yml"
+    )
+    yaml_plugin = PluginManager.get_responsible_plugin(
+        plugins, "path/to/test.yaml"
+    )
+    ini_plugin = PluginManager.get_responsible_plugin(
+        plugins, "path/to/tox.ini"
+    )
     properties_plugin = PluginManager.get_responsible_plugin(
-        "path/to/applications.properties"
+        plugins, "path/to/applications.properties"
     )
-    toml_plugin = PluginManager.get_responsible_plugin("path/to/test.toml")
+    toml_plugin = PluginManager.get_responsible_plugin(
+        plugins, "path/to/test.toml"
+    )
     cypress_plugin = PluginManager.get_responsible_plugin(
-        "path/to/cypress.json"
+        plugins, "path/to/cypress.json"
     )
     tsconfig_plugin = PluginManager.get_responsible_plugin(
-        "path/to/tsconfig.json"
+        plugins, "path/to/tsconfig.json"
     )
     pyproject_plugin = PluginManager.get_responsible_plugin(
-        "path/to/pyproject.toml"
+        plugins, "path/to/pyproject.toml"
     )
 
     assert docker_plugin.concept_name == "docker"


### PR DESCRIPTION
- option added to `init` and `analyze` command
- `init_network` and `PluginManager` revised
- plugins are now fetched once, instead for each file

Fix #126 